### PR TITLE
fix: ensure proper line separation for n-tuples end markers in MS JCAMP-DX files

### DIFF
--- a/chem_spectra/lib/composer/ms.py
+++ b/chem_spectra/lib/composer/ms.py
@@ -44,7 +44,7 @@ class MSComposer(BaseComposer):
         return ['##NTUPLES={}\n'.format('MASS SPECTRUM')]
 
     def __gen_ntuples_end(self):
-        return ['##END NTUPLES={}\n'.format('MASS SPECTRUM')]
+        return ['\n##END NTUPLES={}\n'.format('MASS SPECTRUM')]
 
     def __gen_config(self):
         return [

--- a/chem_spectra/lib/composer/ms.py
+++ b/chem_spectra/lib/composer/ms.py
@@ -74,7 +74,7 @@ class MSComposer(BaseComposer):
         ms_tempfile.seek(0)
         lines = ms_tempfile.readlines()
         decoded_lines = [line.decode('utf-8').strip() for line in lines]
-        msspcs = '\n'.join(decoded_lines) + "\n"
+        msspcs = '\n'.join(decoded_lines) + '\n'
         ms_tempfile.close()
         return msspcs
 

--- a/chem_spectra/lib/composer/ms.py
+++ b/chem_spectra/lib/composer/ms.py
@@ -44,7 +44,7 @@ class MSComposer(BaseComposer):
         return ['##NTUPLES={}\n'.format('MASS SPECTRUM')]
 
     def __gen_ntuples_end(self):
-        return ['\n##END NTUPLES={}\n'.format('MASS SPECTRUM')]
+        return ['##END NTUPLES={}\n'.format('MASS SPECTRUM')]
 
     def __gen_config(self):
         return [
@@ -74,7 +74,7 @@ class MSComposer(BaseComposer):
         ms_tempfile.seek(0)
         lines = ms_tempfile.readlines()
         decoded_lines = [line.decode('utf-8').strip() for line in lines]
-        msspcs = '\n'.join(decoded_lines)
+        msspcs = '\n'.join(decoded_lines) + "\n"
         ms_tempfile.close()
         return msspcs
 

--- a/tests/test_ms.py
+++ b/tests/test_ms.py
@@ -19,14 +19,15 @@ def test_ms_mzml_converter_composer():
         mscv = MSConverter(file, params)
         mscp = MSComposer(mscv)
 
-    lines = mscp.tf_jcamp().read()[:800] \
-                .decode('utf-8', errors='ignore').split('\n')
+    content = mscp.tf_jcamp().read().decode('utf-8', errors='ignore')
+    lines = content.split('\n')
 
     assert '##$CSSCANAUTOTARGET=24' in lines
     assert '##$CSSCANEDITTARGET=24' in lines
     assert '##$CSSCANCOUNT=24' in lines
     assert '##$CSTHRESHOLD=0.05' in lines
     assert '51.012176513671875, 34359.0' in lines
+    assert '##END NTUPLES=MASS SPECTRUM' in lines
 
 
 def test_ms_jcamp_converter_composer():


### PR DESCRIPTION
This pull request fixes an issue where the threshold line disappears when uploading, re-uploading, or modifying MS JCAMP-DX files in ChemSpectra.

## Changes:
Fixed JCAMP File Formatting:

Added a newline before '##END NTUPLES=MASS SPECTRUM' in MSComposer to ensure it is correctly placed on a separate line.

## Updated Unit Tests:
Adjusted tests to verify that '##END NTUPLES=MASS SPECTRUM' appears correctly in the generated JCAMP-DX files.

## Related Issue:
This PR addresses the issue reported in [ComPlat/chem-spectra-app#214](https://github.com/ComPlat/chem-spectra-app/issues/214).

This fix ensures that the threshold line remains visible and editable after any file modifications in ChemSpectra.