### PR TITLE
Fix IR preview image margin regression

### DIFF
--- a/chem_spectra/lib/composer/ni.py
+++ b/chem_spectra/lib/composer/ni.py
@@ -523,7 +523,7 @@ class NIComposer(BaseComposer):
 
         self.__generate_info_box(plt)
 
-        y_boundary_max = self.__draw_peaks(plt, x_peaks, y_peaks, h, w, y_boundary_max*1.5)
+        y_boundary_max = self.__draw_peaks(plt, x_peaks, y_peaks, h, w, y_boundary_max * (1.1 if self.core.is_ir else 1.5))
 
 
         plt.ylim(


### PR DESCRIPTION
This PR fixes an issue introduced in v1.2.1 where IR spectrum preview images were rendered with too much top margin due to a hardcoded scaling factor:

`y_boundary_max = self.__draw_peaks(..., y_boundary_max * 1.5)`

IR spectra use inverted peaks, so this extra margin is not needed. The fix applies a reduced factor for IR spectra:

`y_boundary_max = self.__draw_peaks(..., y_boundary_max * (1.1 if self.core.is_ir else 1.5))`

### Before
![image](https://github.com/user-attachments/assets/41005a82-3b0b-4439-8872-397aef6541e4)

### After
![image](https://github.com/user-attachments/assets/8062cbc4-97a5-4724-8e56-0e9a3826f331)

Closes [#230](https://github.com/ComPlat/chem-spectra-app/issues/230)