### PR TITLE
Skip empty JCAMP files in BagIt ZIPs

### DIFF
--- a/chem_spectra/lib/converter/bagit/base.py
+++ b/chem_spectra/lib/converter/bagit/base.py
@@ -46,7 +46,11 @@ class BagItBaseConverter:
                 tf_csv = mscp.tf_csv()
                 list_csv.append(tf_csv)
             else:
-                nicv = JcampNIConverter(base_cv)
+                try:
+                    nicv = JcampNIConverter(base_cv)
+                except KeyError as err:
+                    print(f"Skip empty JCAMP {file_name}: {err}")
+                    continue
                 nicp = NIComposer(nicv)
                 list_composer.append(nicp)
                 tf_jcamp = nicp.tf_jcamp()


### PR DESCRIPTION
## What was wrong
If the first .jdx inside a BagIt archive had no XY data, JcampNIConverter raised a KeyError.
ChemSpectra stopped processing and returned a 500 error, even when valid files followed. (Issue #238)

## What this PR does
- Wraps the creation of JcampNIConverter in a try/except.
- Files that miss both XYDATA and PEAKTABLE / XYPOINTS are skipped and logged.
- Processing continues with the remaining (valid) files.

## Result
- ChemSpectra now imports BagIt archives even if some .jdx files are empty.
- Users see the valid spectra; empty files are silently ignored (a warning is logged on the backend).

Closes #238