### PR TITLE
Add $CSSOLVENT* metadata to align simulated NMR peaks with spectrum

### DIFF
--- a/chem_spectra/lib/converter/fid/base.py
+++ b/chem_spectra/lib/converter/fid/base.py
@@ -35,7 +35,9 @@ class FidBaseConverter:
         dic['XUNITS'] = ['PPM']
         dic['YUNITS'] = ['ARBITRARY']
         dic['TITLE'] = ['FID {}'.format('.'.join(fname.split('.')[:-1]))]
-
+        dic['$CSSOLVENTX']     = [f'{offset:.6f}']
+        dic['$CSSOLVENTVALUE'] = ['0.000000']
+        dic['$CSSOLVENTNAME']  = ['AUTO-OFFSET']
         # process data (i.e. ys)
         data = ng.bruker.remove_digital_filter(dic, data)  # remove the digital filter   # noqa: E501
         data = ng.proc_base.zf_size(data, num_pts)    # zero fill to 32768 points   # noqa: E501

--- a/chem_spectra/lib/converter/fid/bruker.py
+++ b/chem_spectra/lib/converter/fid/bruker.py
@@ -78,7 +78,9 @@ class FidHasBruckerProcessed:
         processed_dic['XUNITS'] = ['PPM']
         processed_dic['YUNITS'] = ['ARBITRARY']
         processed_dic['TITLE'] = ['FID {}'.format('.'.join(fname.split('.')[:-1]))]
-
+        processed_dic['$CSSOLVENTX']     = [f'{offset:.6f}']
+        processed_dic['$CSSOLVENTVALUE'] = ['0.000000']
+        processed_dic['$CSSOLVENTNAME']  = ['AUTO-OFFSET']
         return processed_dic
 
     def __process_raw_data(self, dic, data):


### PR DESCRIPTION
## What was wrong
When a Bruker 13C dataset lacks the SR parameter, the experimental axis is shifted but the front-end still plots simulated peaks at 0 ppm.
Because the created JCAMP did not include $CSSOLVENTX, $CSSOLVENTVALUE, and $CSSOLVENTNAME, the UI could not compute the offset, so the red peak appeared to the left of the spectrum.

![image](https://github.com/user-attachments/assets/79e385ec-78d8-49c0-8588-3114680b6769)

## What this PR does

 - writes
```
        dic['$CSSOLVENTX']     = [f'{offset:.6f}']
        dic['$CSSOLVENTVALUE'] = ['0.000000']
        dic['$CSSOLVENTNAME']  = ['AUTO-OFFSET']
```

## Result
The front-end now subtracts the correct offset and the red simulated peaks are aligned with the blue spectrum for every file, with or without SR. No impact on datasets that were already correct.

![image](https://github.com/user-attachments/assets/07f08fca-1cb3-46d2-9894-7c110fae674f)

Closes ComPlat/react-spectra-editor#251