### PR TITLE
fix: remove Bruker 'ser' fallback in search_brucker_binary

### DIFF
--- a/chem_spectra/model/transformer.py
+++ b/chem_spectra/model/transformer.py
@@ -36,10 +36,10 @@ def search_brucker_binary(td):
     try:
         has_processed_files = search_processed_file(td)
         target_dir = find_dir(td, 'fid')
-        if not target_dir:
-            target_dir = find_dir(td, 'ser')
-        return target_dir, has_processed_files
-    except:     # noqa: E722
+        if target_dir:
+            return target_dir, has_processed_files
+        return False, has_processed_files
+    except Exception:  # noqa: E722
         return False, False
 
 def search_processed_file(td):


### PR DESCRIPTION
# Description
This PR removes the fallback to Bruker 'ser' files in search_brucker_binary.

We only support 1D data with 'fid'. If a 'ser' file (2D) is found, it is now
skipped and the function returns False. This prevents accidental generation
of 1D spectra from unsupported 2D data.