### PR TITLE
fix(ms): set figure dpi to 200 for MS images for consistency

### DIFF
--- a/chem_spectra/lib/composer/ms.py
+++ b/chem_spectra/lib/composer/ms.py
@@ -115,6 +115,7 @@ class MSComposer(BaseComposer):
 
     def tf_img(self):
         plt.rcParams['figure.figsize'] = [16, 9]
+        plt.rcParams['figure.dpi'] = 200
         plt.rcParams['font.size'] = 14
         # PLOT data
         blues_x, blues_y, greys_x, greys_y, _ = self.prism_peaks()


### PR DESCRIPTION
This PR updates the MS image generation to explicitly set `plt.rcParams['figure.dpi'] = 200`,  
aligning it with NI image generation.  

- Before: MS images used the matplotlib default DPI (100), resulting in 1600x900 px.  
- After: MS images now use 200 DPI, resulting in 3200x1800 px.  

This ensures consistent image quality across NI and MS spectra,  
and provides higher resolution output, especially useful for printing.  