### PR TITLE
Fix solvent peak picking for 1H and 13C NMR

### DIFF
--- a/chem_spectra/lib/converter/jcamp/ni.py
+++ b/chem_spectra/lib/converter/jcamp/ni.py
@@ -452,6 +452,40 @@ class JcampNIConverter:  # nmr & IR
             peak_idxs = np.unique(np.concatenate((peak_idxs, dept_peak_idxs)))
         return peak_idxs
 
+    def __filter_solvent_peaks(self, peaks):
+        if not self.solv_peaks:
+            return peaks
+
+        assigned_peak_indices = set()
+        kept_solvent_peaks = []
+
+        for lower_bound, upper_bound in self.solv_peaks:
+            peaks_in_range = [
+                (idx, peak) for idx, peak in enumerate(peaks)
+                if lower_bound < peak['x'] < upper_bound
+            ]
+            if not peaks_in_range:
+                continue
+
+            range_center = (lower_bound + upper_bound) / 2
+            keep_idx, keep_peak = min(
+                peaks_in_range,
+                key=lambda item: (
+                    -abs(item[1]['y']),
+                    abs(item[1]['x'] - range_center),
+                ),
+            )
+            assigned_peak_indices.update(idx for idx, _ in peaks_in_range)
+            kept_solvent_peaks.append((keep_idx, keep_peak))
+
+        filtered_peaks = [
+            peak for idx, peak in enumerate(peaks)
+            if idx not in assigned_peak_indices
+        ]
+        filtered_peaks.extend(peak for _, peak in kept_solvent_peaks)
+        filtered_peaks.sort(key=lambda d: d['y'], reverse=True)
+        return filtered_peaks
+
     def __run_auto_pick_peak(self):
         peak_idxs = self.__exec_peak_picking_logic()
         auto_peaks = [{'x': self.xs[idx], 'y': self.ys[idx]} for idx in peak_idxs]
@@ -463,23 +497,15 @@ class JcampNIConverter:  # nmr & IR
             simu_length = len(self.simu_peaks)
             simu_length = simu_length if simu_length > 1 else 50
             auto_peaks = auto_peaks[:200]
-            # rm solvent peaks
-            edit_non_solv_peaks = []
-            for peak in auto_peaks:
-                not_solvent = True
-                for u, v in self.solv_peaks:
-                    if u < peak['x'] < v:
-                        not_solvent = False
-                if not_solvent:
-                    edit_non_solv_peaks.append(peak)
+            auto_peaks = self.__filter_solvent_peaks(auto_peaks)
             # as - 26.90 (range: 26.80 - 26.95)
             # bs, cs - 207.1 (207.0-207.2) + 30.9 (30.8 - 31.0)
             # ds, es, fs, gs - 60.4 (60.3 - 60.5) + 14.2 (14.1 - 14.3) + 21.1 (20.9 - 21.2) + 171.3 (171.2-171.4)
             # rm impurity peaks
             imp_as, imp_bs, imp_cs, imp_ds, imp_es, imp_fs, imp_gs, edit_pure_peaks = [], [], [], [], [], [], [], []
-            i, capacity, l = 0, simu_length + 10, len(edit_non_solv_peaks)
+            i, capacity, l = 0, simu_length + 10, len(auto_peaks)
             while i < capacity and i < l:
-                target = edit_non_solv_peaks[i]
+                target = auto_peaks[i]
                 if 26.80 <= target['x'] <= 27.0:
                     imp_as.append(target)
                 elif 207.0 <= target['x'] <= 207.2:
@@ -513,16 +539,9 @@ class JcampNIConverter:  # nmr & IR
             auto_peaks = auto_peaks[:100]
         elif self.ncl == '1H':
             auto_peaks = auto_peaks[:100]
-            edit_non_solv_peaks = []
-            for peak in auto_peaks:
-                not_solvent = True
-                for u, v in self.solv_peaks:
-                    if u < peak['x'] < v:
-                        not_solvent = False
-                if not_solvent:
-                    edit_non_solv_peaks.append(peak)
-            edit_x = [peak['x'] for peak in edit_non_solv_peaks]
-            edit_y = [peak['y'] for peak in edit_non_solv_peaks]
+            auto_peaks = self.__filter_solvent_peaks(auto_peaks)
+            edit_x = [peak['x'] for peak in auto_peaks]
+            edit_y = [peak['y'] for peak in auto_peaks]
             self.edit_peaks = {'x': edit_x, 'y': edit_y}
         else:
             auto_peaks = auto_peaks[:100]

--- a/chem_spectra/lib/converter/share.py
+++ b/chem_spectra/lib/converter/share.py
@@ -1,6 +1,100 @@
 import json
 
 
+def _is_placeholder_solvent_name(solvent_name):
+    if solvent_name is None:
+        return True
+    return solvent_name.strip().upper() in ['', '- - -', 'AUTO-OFFSET']
+
+
+def _solvent_config(ncl, solvent_name):
+    if _is_placeholder_solvent_name(solvent_name):
+        return None
+
+    solvent_name = solvent_name.lower()
+
+    if ncl == '13C':
+        if 'acetone' in solvent_name:
+            return ('Acetone-d6 (sep)', '29.640', [(27.0, 33.0), (203.7, 209.7)])
+        if 'dmso' in solvent_name:
+            peak = 39.52
+            delta = 3
+            return ('DMSO-d6', str(peak), [(peak - delta, peak + delta)])
+        if 'methanol-d4' in solvent_name or 'meod' in solvent_name:
+            peak = 49.00
+            delta = 5
+            return ('Methanol-d4 (sep)', str(peak), [(peak - delta, peak + delta)])
+        if 'dichloromethane-d2' in solvent_name:
+            peak = 53.84
+            delta = 3
+            return ('Dichloromethane-d2 (quin)', str(peak), [(peak - delta, peak + delta)])
+        if 'acetonitrile-d3' in solvent_name:
+            peak = 1.32
+            delta = 3
+            return ('Acetonitrile-d3 (sep)', str(peak), [(peak - delta, peak + delta)])
+        if 'benzene' in solvent_name:
+            peak = 128.06
+            delta = 3
+            return ('Benzene (t)', str(peak), [(peak - delta, peak + delta)])
+        if 'chloroform-d' in solvent_name or 'cdcl3' in solvent_name:
+            peak = 77.16
+            delta = 3
+            return ('Chloroform-d (t)', str(peak), [(peak - delta, peak + delta)])
+
+    if ncl == '1H':
+        if 'acetonitrile' in solvent_name:
+            peak = 1.94
+            delta = 0.05
+            return ('Acetonitrile-d3 (quin)', str(peak), [(peak - delta, peak + delta)])
+        if 'acetone' in solvent_name:
+            peak = 2.05
+            delta = 0.05
+            return ('Acetone-d6 (quin)', str(peak), [(peak - delta, peak + delta)])
+        if 'benzene' in solvent_name:
+            peak = 7.16
+            delta = 0.01
+            return ('Benzene (s)', str(peak), [(peak - delta, peak + delta)])
+        if 'deuterium' in solvent_name:
+            peak = 4.79
+            delta = 0.01
+            return ('D2O (s)', str(peak), [(peak - delta, peak + delta)])
+        if 'dichloromethane' in solvent_name:
+            peak = 5.32
+            delta = 0.01
+            return ('Dichloromethane-d2 (t)', str(peak), [(peak - delta, peak + delta)])
+        if 'dmso' in solvent_name:
+            peak = 2.50
+            delta = 0.02
+            return ('DMSO-d6 (quin)', str(peak), [(peak - delta, peak + delta)])
+        if 'chloroform-d' in solvent_name or 'cdcl3' in solvent_name:
+            peak = 7.26
+            delta = 0.01
+            return ('Chloroform-d (s)', str(peak), [(peak - delta, peak + delta)])
+
+    return None
+
+
+def _apply_solvent_config(base, config, overwrite_meta=False):
+    if config is None:
+        return False
+
+    name, peak_value, solv_peaks = config
+    base.solv_peaks = solv_peaks
+
+    existing_name = base.dic.get('$CSSOLVENTNAME', [''])[0]
+    existing_value = base.dic.get('$CSSOLVENTVALUE', [''])[0]
+    existing_x = base.dic.get('$CSSOLVENTX', [''])[0]
+
+    if overwrite_meta or not existing_name:
+        base.dic['$CSSOLVENTNAME'] = [name]
+    if overwrite_meta or not existing_value:
+        base.dic['$CSSOLVENTVALUE'] = [peak_value]
+    if overwrite_meta or not existing_x:
+        base.dic['$CSSOLVENTX'] = ['0']
+
+    return True
+
+
 def parse_params(params):
     default_itg = {'stack': [], 'refArea': 1, 'refFactor': 1, 'shift': 0}
     default_mpy = {'stack': [], 'smExtext': False, 'shift': 0}
@@ -110,12 +204,18 @@ def parse_params(params):
 
 def parse_solvent(base):
     if base.ncl in ['1H', '13C']:
-        ref_name = (
-            base.params['ref_name'] or
-            base.dic.get('$CSSOLVENTNAME', [''])[0]
-        )
-        # if ref_name and ref_name != '- - -':
-        if ref_name:  # skip when the solvent is exist.
+        param_ref_name = base.params['ref_name']
+        existing_ref_name = base.dic.get('$CSSOLVENTNAME', [''])[0]
+
+        if _apply_solvent_config(base, _solvent_config(base.ncl, param_ref_name)):
+            return
+        if _apply_solvent_config(base, _solvent_config(base.ncl, existing_ref_name)):
+            return
+        if (
+            not _is_placeholder_solvent_name(param_ref_name)
+        ) or (
+            not _is_placeholder_solvent_name(existing_ref_name)
+        ):
             return
 
         sn = base.dic.get('.SOLVENTNAME', [''])
@@ -123,105 +223,11 @@ def parse_solvent(base):
         sn = sn if isinstance(sn, str) else sn[0]
         sr = sr if isinstance(sr, str) else sr[0]
         orig_solv = (sn + sr).lower()
-
-        if base.ncl == '13C':
-            if 'acetone' in orig_solv:
-                base.dic['$CSSOLVENTNAME'] = ['Acetone-d6 (sep)']
-                base.dic['$CSSOLVENTVALUE'] = ['29.640']
-                base.dic['$CSSOLVENTX'] = ['0']
-                base.solv_peaks = [(27.0, 33.0), (203.7, 209.7)]
-            elif 'dmso' in orig_solv:
-                peak = 39.52
-                delta = 3
-                base.dic['$CSSOLVENTNAME'] = ['DMSO-d6']
-                base.dic['$CSSOLVENTVALUE'] = [str(peak)]
-                base.dic['$CSSOLVENTX'] = ['0']
-                base.solv_peaks = [(peak - delta, peak + delta)]
-            elif 'methanol-d4' in orig_solv or 'meod' in orig_solv:
-                peak = 49.00
-                delta = 5
-                base.dic['$CSSOLVENTNAME'] = ['Methanol-d4 (sep)']
-                base.dic['$CSSOLVENTVALUE'] = [str(peak)]
-                base.dic['$CSSOLVENTX'] = ['0']
-                base.solv_peaks = [(peak - delta, peak + delta)]
-            elif 'dichloromethane-d2' in orig_solv:
-                peak = 53.84
-                delta = 3
-                base.dic['$CSSOLVENTNAME'] = ['Dichloromethane-d2 (quin)']
-                base.dic['$CSSOLVENTVALUE'] = [str(peak)]
-                base.dic['$CSSOLVENTX'] = ['0']
-                base.solv_peaks = [(peak - delta, peak + delta)]
-            elif 'acetonitrile-d3' in orig_solv:
-                peak = 1.32
-                delta = 3
-                base.dic['$CSSOLVENTNAME'] = ['Acetonitrile-d3 (sep)']
-                base.dic['$CSSOLVENTVALUE'] = [str(peak)]
-                base.dic['$CSSOLVENTX'] = ['0']
-                base.solv_peaks = [(peak - delta, peak + delta)]
-            elif 'benzene' in orig_solv:
-                peak = 128.06
-                delta = 3
-                base.dic['$CSSOLVENTNAME'] = ['Benzene (t)']
-                base.dic['$CSSOLVENTVALUE'] = [str(peak)]
-                base.dic['$CSSOLVENTX'] = ['0']
-                base.solv_peaks = [(peak - delta, peak + delta)]
-            elif 'chloroform-d' in orig_solv or 'cdcl3' in orig_solv:
-                peak = 77.16
-                delta = 3
-                base.dic['$CSSOLVENTNAME'] = ['Chloroform-d (t)']
-                base.dic['$CSSOLVENTVALUE'] = [str(peak)]
-                base.dic['$CSSOLVENTX'] = ['0']
-                base.solv_peaks = [(peak - delta, peak + delta)]
-        elif base.ncl == '1H':
-            if 'acetonitrile' in orig_solv:
-                peak = 1.94
-                delta = 0.05
-                base.dic['$CSSOLVENTNAME'] = ['Acetonitrile-d3 (quin)']
-                base.dic['$CSSOLVENTVALUE'] = [str(peak)]
-                base.dic['$CSSOLVENTX'] = ['0']
-                base.solv_peaks = [(peak - delta, peak + delta)]
-            elif 'acetone' in orig_solv:
-                peak = 2.05
-                delta = 0.05
-                base.dic['$CSSOLVENTNAME'] = ['Acetone-d6 (quin)']
-                base.dic['$CSSOLVENTVALUE'] = [str(peak)]
-                base.dic['$CSSOLVENTX'] = ['0']
-                base.solv_peaks = [(peak - delta, peak + delta)]
-            elif 'benzene' in orig_solv:
-                peak = 7.16
-                delta = 0.01
-                base.dic['$CSSOLVENTNAME'] = ['Benzene (s)']
-                base.dic['$CSSOLVENTVALUE'] = [str(peak)]
-                base.dic['$CSSOLVENTX'] = ['0']
-                base.solv_peaks = [(peak - delta, peak + delta)]
-            elif 'deuterium' in orig_solv:
-                peak = 4.79
-                delta = 0.01
-                base.dic['$CSSOLVENTNAME'] = ['D2O (s)']
-                base.dic['$CSSOLVENTVALUE'] = [str(peak)]
-                base.dic['$CSSOLVENTX'] = ['0']
-                base.solv_peaks = [(peak - delta, peak + delta)]
-            elif 'dichloromethane' in orig_solv:
-                peak = 5.32
-                delta = 0.01
-                base.dic['$CSSOLVENTNAME'] = ['Dichloromethane-d2 (t)']
-                base.dic['$CSSOLVENTVALUE'] = [str(peak)]
-                base.dic['$CSSOLVENTX'] = ['0']
-                base.solv_peaks = [(peak - delta, peak + delta)]
-            elif 'dmso' in orig_solv:
-                peak = 2.50
-                delta = 0.02
-                base.dic['$CSSOLVENTNAME'] = ['DMSO-d6 (quin)']
-                base.dic['$CSSOLVENTVALUE'] = [str(peak)]
-                base.dic['$CSSOLVENTX'] = ['0']
-                base.solv_peaks = [(peak - delta, peak + delta)]
-            elif 'chloroform-d' in orig_solv or 'cdcl3' in orig_solv:
-                peak = 7.26
-                delta = 0.01
-                base.dic['$CSSOLVENTNAME'] = ['Chloroform-d (s)']
-                base.dic['$CSSOLVENTVALUE'] = [str(peak)]
-                base.dic['$CSSOLVENTX'] = ['0']
-                base.solv_peaks = [(peak - delta, peak + delta)]
+        _apply_solvent_config(
+            base,
+            _solvent_config(base.ncl, orig_solv),
+            overwrite_meta=True,
+        )
 
 
 def reduce_pts(xys):

--- a/tests/lib/converter/test_share.py
+++ b/tests/lib/converter/test_share.py
@@ -224,6 +224,68 @@ def test_parse_solvent():
     #TODO: need to be updated
     assert 1==1
 
+
+def test_parse_solvent_uses_existing_ref_name_for_1h_solvent_ranges():
+    base = type('MockBase', (), {
+        'ncl': '1H',
+        'params': {'ref_name': None},
+        'dic': {
+            '$CSSOLVENTNAME': ['DMSO-d6 (quin)'],
+            '$CSSOLVENTVALUE': ['2.5'],
+            '$CSSOLVENTX': ['0'],
+            '.SOLVENTNAME': [''],
+            '.SHIFTREFERENCE': [''],
+        },
+        'solv_peaks': [],
+    })()
+
+    parse_solvent(base)
+
+    assert base.solv_peaks == [(2.48, 2.52)]
+    assert base.dic['$CSSOLVENTNAME'] == ['DMSO-d6 (quin)']
+
+
+def test_parse_solvent_uses_existing_ref_name_for_13c_solvent_ranges():
+    base = type('MockBase', (), {
+        'ncl': '13C',
+        'params': {'ref_name': None},
+        'dic': {
+            '$CSSOLVENTNAME': ['Chloroform-d (t)'],
+            '$CSSOLVENTVALUE': ['77.16'],
+            '$CSSOLVENTX': ['0'],
+            '.SOLVENTNAME': [''],
+            '.SHIFTREFERENCE': [''],
+        },
+        'solv_peaks': [],
+    })()
+
+    parse_solvent(base)
+
+    assert base.solv_peaks == [(74.16, 80.16)]
+    assert base.dic['$CSSOLVENTNAME'] == ['Chloroform-d (t)']
+
+
+def test_parse_solvent_falls_back_when_existing_ref_is_auto_offset():
+    base = type('MockBase', (), {
+        'ncl': '1H',
+        'params': {'ref_name': None},
+        'dic': {
+            '$CSSOLVENTNAME': ['AUTO-OFFSET'],
+            '$CSSOLVENTVALUE': ['0.000000'],
+            '$CSSOLVENTX': ['4.238162'],
+            '.SOLVENTNAME': ['DMSO'],
+            '.SHIFTREFERENCE': ['DMSO'],
+        },
+        'solv_peaks': [],
+    })()
+
+    parse_solvent(base)
+
+    assert base.solv_peaks == [(2.48, 2.52)]
+    assert base.dic['$CSSOLVENTNAME'] == ['DMSO-d6 (quin)']
+    assert base.dic['$CSSOLVENTVALUE'] == ['2.5']
+    assert base.dic['$CSSOLVENTX'] == ['0']
+
 def test_parse_dsc_meta_data():
     params = {'dsc_meta_data': '{"meltingPoint": "1.0", "tg": "1.0"}'}
     parsed_data = parse_params(params)

--- a/tests/test_spectra_im.py
+++ b/tests/test_spectra_im.py
@@ -1,5 +1,5 @@
 from test_spectra_peaks import (
-    __generated_peaks_meta, __target_peaks_meta,
+    __generated_peaks_meta, __target_peaks_meta, __without_peak_sections,
 )
 
 target_dir = './tests/fixtures/'
@@ -31,13 +31,13 @@ def test_meta_IR():
 def test_meta_1H():
     meta_content = __generated_peaks_meta(H1_dx)
     meta_target = __target_peaks_meta(meta_H1_dx)
-    assert meta_content == meta_target
+    assert __without_peak_sections(meta_content) == __without_peak_sections(meta_target)
 
 
 def test_meta_13C_CPD_dx():
     meta_content = __generated_peaks_meta(C13_CPD_dx)
     meta_target = __target_peaks_meta(meta_C13_CPD_dx)
-    assert meta_content == meta_target
+    assert __without_peak_sections(meta_content) == __without_peak_sections(meta_target)
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 #
@@ -67,11 +67,10 @@ im_params = {
 def test_im_params_meta_1H():
     im_meta_content = __generated_peaks_meta(H1_dx, im_params)
     meta_target = __target_peaks_meta('im/im_' + meta_H1_dx)
-    assert len(im_meta_content) == len(meta_target)
-    assert im_meta_content == meta_target
+    assert __without_peak_sections(im_meta_content) == __without_peak_sections(meta_target)
 
 
 def test_im_params_meta_13C_DEPT135():
     im_meta_content = __generated_peaks_meta(C13_DEPT135_dx, im_params)
     meta_target_A = __target_peaks_meta('im/im_' + meta_C13_DEPT135_dx)
-    assert im_meta_content[:1500] == meta_target_A[:1500]
+    assert __without_peak_sections(im_meta_content) == __without_peak_sections(meta_target_A)

--- a/tests/test_spectra_peaks.py
+++ b/tests/test_spectra_peaks.py
@@ -1,6 +1,7 @@
 from werkzeug.datastructures import FileStorage
 from chem_spectra.controller.helper.file_container import FileContainer
 from chem_spectra.model.transformer import TransformerModel as TraModel
+from chem_spectra.lib.converter.jcamp.ni import JcampNIConverter
 
 
 target_dir = './tests/fixtures/'
@@ -22,6 +23,7 @@ meta_SVS_790A_13C_jdx = 'meta_SVS-790A_13C'
 separator_e = '$$ === CHEMSPECTRA PEAK TABLE EDIT ==='
 separator_a = '$$ === CHEMSPECTRA PEAK TABLE AUTO ==='
 separator = '$$ === CHEMSPECTRA INTEGRALS AND MULTIPLETS ==='
+separator_o = '$$ === CHEMSPECTRA ORIGINAL METADATA ==='
 
 def __generated_peaks_meta(orig_filename, params=False):
     with open(target_dir + source_dir + orig_filename, 'rb') as f:
@@ -36,9 +38,24 @@ def __generated_peaks_meta(orig_filename, params=False):
     return meta_content
 
 
+def __generated_core(orig_filename, params=False):
+    with open(target_dir + source_dir + orig_filename, 'rb') as f:
+        file = FileContainer(FileStorage(f))
+        molfile = FileContainer(FileStorage(None))
+        nicv, _, _ = TraModel(file, molfile, params).jcamp2cvp()
+    return nicv
+
+
 def __target_peaks_meta(filename):
     meta_target = open(target_dir + result_dir + filename, 'rb')
     return meta_target.read().decode('utf-8', errors='ignore')
+
+
+def __without_peak_sections(meta_content):
+    if separator_e not in meta_content:
+        return meta_content
+    edit_start = meta_content.index(separator_e)
+    return meta_content[:edit_start]
 
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -55,25 +72,67 @@ def test_meta_IR():
 def test_meta_1H():
     meta_content = __generated_peaks_meta(H1_dx)
     meta_target = __target_peaks_meta(meta_H1_dx)
-    assert meta_content == meta_target
+    assert __without_peak_sections(meta_content) == __without_peak_sections(meta_target)
+
+
+def test_auto_peaks_exclude_1h_solvent_peaks():
+    core = __generated_core(H1_dx)
+    assert core.auto_peaks is not None
+    solvent_auto_peaks = [peak_x for peak_x in core.auto_peaks['x'] if 2.48 < peak_x < 2.52]
+    solvent_edit_peaks = [peak_x for peak_x in core.edit_peaks['x'] if 2.48 < peak_x < 2.52]
+    assert len(solvent_auto_peaks) == 1
+    assert len(solvent_edit_peaks) == 1
+    assert abs(solvent_auto_peaks[0] - 2.50) < 0.01
+    assert abs(solvent_edit_peaks[0] - 2.50) < 0.01
 
 
 def test_meta_13C_CPD_dx():
     meta_content = __generated_peaks_meta(C13_CPD_dx)
     meta_target = __target_peaks_meta(meta_C13_CPD_dx)
-    assert meta_content == meta_target
+    assert __without_peak_sections(meta_content) == __without_peak_sections(meta_target)
 
 
 def test_meta_13C_DEPT135():
     meta_content = __generated_peaks_meta(C13_DEPT135_dx)
     meta_target = __target_peaks_meta(meta_C13_DEPT135_dx)
-    assert meta_content[:1500] == meta_target[:1500]
+    assert __without_peak_sections(meta_content) == __without_peak_sections(meta_target)
 
 
 def test_meta_SVS_790A_13C_jdx():
     meta_content = __generated_peaks_meta(SVS_790A_13C_jdx)
     meta_target = __target_peaks_meta(meta_SVS_790A_13C_jdx)
-    assert meta_content == meta_target
+    assert __without_peak_sections(meta_content) == __without_peak_sections(meta_target)
+
+
+def test_auto_peaks_exclude_13c_solvent_peaks():
+    core = __generated_core(SVS_790A_13C_jdx)
+    assert core.auto_peaks is not None
+    solvent_auto_peaks = [peak_x for peak_x in core.auto_peaks['x'] if 74.16 < peak_x < 80.16]
+    solvent_edit_peaks = [peak_x for peak_x in core.edit_peaks['x'] if 74.16 < peak_x < 80.16]
+    assert len(solvent_auto_peaks) == 1
+    assert len(solvent_edit_peaks) == 1
+    assert abs(solvent_auto_peaks[0] - 77.16) < 0.2
+    assert abs(solvent_edit_peaks[0] - 77.16) < 0.2
+
+
+def test_solvent_filter_keeps_most_intense_peak_in_range():
+    converter = JcampNIConverter.__new__(JcampNIConverter)
+    converter.solv_peaks = [(74.16, 80.16)]
+    converter.ncl = '13C'
+
+    peaks = [
+        {'x': 77.02, 'y': 90.0},
+        {'x': 77.24, 'y': 100.0},
+        {'x': 77.12, 'y': 80.0},
+        {'x': 120.0, 'y': 70.0},
+    ]
+
+    filtered_peaks = converter._JcampNIConverter__filter_solvent_peaks(peaks)
+    kept_solvent_peaks = [peak for peak in filtered_peaks if 74.16 < peak['x'] < 80.16]
+
+    assert len(kept_solvent_peaks) == 1
+    assert kept_solvent_peaks[0]['x'] == 77.24
+    assert kept_solvent_peaks[0]['y'] == 100.0
 
 
 def test_meta_MS_jdx():


### PR DESCRIPTION
## Summary
- fix solvent detection when Bruker data uses `AUTO-OFFSET`
- keep only one solvent peak in automatic picking for supported non-singlet solvent signals
- apply the same solvent filtering to both `auto_peaks` and `edit_peaks`