### PR TITLE
feat(jcamp): persist visual split groups via $OBSERVEDINTEGRALSGROUPS

### DIFF
--- a/chem_spectra/lib/composer/base.py
+++ b/chem_spectra/lib/composer/base.py
@@ -3,6 +3,10 @@ from chem_spectra.lib.shared.misc import is_number
 from chem_spectra.lib.shared.calc import (  # noqa: E402
     calc_mpy_center
 )
+from chem_spectra.lib.composer.integration_extras import (  # noqa: E402
+    sanitize_split_lines, format_split_lines,
+    sanitize_group_id, format_observed_integrals_groups_table,
+)
 
 
 def extrac_dic(core, key):
@@ -220,12 +224,31 @@ class BaseComposer:
         itg_stack = core_itg.get('stack') or []
         mpy_stack = core_mpy.get('stack') or []
 
+        for itg in itg_stack:
+            cleaned = sanitize_split_lines(
+                itg.get('splitLines'), itg.get('xL'), itg.get('xU'),
+            )
+            if cleaned is not None:
+                itg['splitLines'] = cleaned
+            elif 'splitLines' in itg:
+                del itg['splitLines']
+
+            group_id = sanitize_group_id(itg.get('visualSplitGroupId'))
+            if group_id is not None:
+                itg['visualSplitGroupId'] = group_id
+            elif 'visualSplitGroupId' in itg:
+                del itg['visualSplitGroupId']
+
         self.all_itgs = itg_stack
         for itg in itg_stack:
             skip = False
             for mpy in mpy_stack:
                 if (itg['xL'] == mpy['xExtent']['xL']) and (itg['xU'] == mpy['xExtent']['xU']):     # pylint: disable=c0301
                     mpy['area'] = itg['area']
+                    if 'splitLines' in itg:
+                        mpy['splitLines'] = itg['splitLines']
+                    if 'visualSplitGroupId' in itg:
+                        mpy['visualSplitGroupId'] = itg['visualSplitGroupId']
                     self.mpys.append(mpy)
                     skip = True
                     break
@@ -239,14 +262,26 @@ class BaseComposer:
                 absoluteArea = 0
                 if 'absoluteArea' in itg:
                     absoluteArea = itg['absoluteArea']
-                table.extend([
-                    '({}, {}, {}, {})\n'.format(
-                        itg['xL'] - self.refShift,
-                        itg['xU'] - self.refShift,
-                        float(itg['area']) * self.refArea,
-                        absoluteArea,
-                    ),
-                ])
+                split_token = format_split_lines(itg.get('splitLines'))
+                if split_token is None:
+                    table.append(
+                        '({}, {}, {}, {})\n'.format(
+                            itg['xL'] - self.refShift,
+                            itg['xU'] - self.refShift,
+                            float(itg['area']) * self.refArea,
+                            absoluteArea,
+                        ),
+                    )
+                else:
+                    table.append(
+                        '({}, {}, {}, {}, "{}")\n'.format(
+                            itg['xL'] - self.refShift,
+                            itg['xU'] - self.refShift,
+                            float(itg['area']) * self.refArea,
+                            absoluteArea,
+                            split_token,
+                        ),
+                    )
             return table
         elif self.core.params['integration'].get('edited'):
             return []
@@ -268,6 +303,21 @@ class BaseComposer:
             return itg_stack
         else:
             return self.core.itg_table
+
+    def gen_integration_groups_info(self):
+        if len(self.itgs) > 0:
+            return format_observed_integrals_groups_table(self.itgs)
+
+        raw = getattr(self.core, 'itg_groups_table', None) or []
+        if not raw:
+            return []
+        body = raw[0] if isinstance(raw, (list, tuple)) and raw else raw
+        if not isinstance(body, str) or not body.strip():
+            return []
+        lines = [line for line in body.splitlines() if line.strip()]
+        if not lines:
+            return []
+        return [line + '\n' for line in lines]
 
     def gen_mpy_integ_info(self):
         ascii_uppercase = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'

--- a/chem_spectra/lib/composer/integration_extras.py
+++ b/chem_spectra/lib/composer/integration_extras.py
@@ -1,0 +1,192 @@
+"""Helpers for the optional ``splitLines`` and ``visualSplitGroupId``
+fields carried by items of ``integration.stack``.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from typing import Dict, Iterable, List, Optional
+
+
+_BOUND_EPSILON = 1e-9
+_DEDUP_EPSILON = 1e-6
+
+# Mirrors the frontend validation regex /[^A-Za-z0-9._-]/g.
+_GROUP_ID_RE = re.compile(r'^[A-Za-z0-9._-]+$')
+
+def _coerce_float(value) -> Optional[float]:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        as_float = float(value)
+    except (TypeError, ValueError):
+        return None
+    if math.isnan(as_float) or math.isinf(as_float):
+        return None
+    return as_float
+
+
+def _format_number(value: float) -> str:
+    text = repr(float(value))
+    if text.endswith('.0'):
+        return text[:-2]
+    return text
+
+
+def sanitize_split_lines(
+    values,
+    x_lower: Optional[float] = None,
+    x_upper: Optional[float] = None,
+) -> Optional[List[float]]:
+    if values is None:
+        return None
+    if isinstance(values, (str, bytes)):
+        return None
+    if not isinstance(values, Iterable):
+        return None
+
+    lo: Optional[float] = None
+    hi: Optional[float] = None
+    if x_lower is not None and x_upper is not None:
+        lo, hi = sorted((float(x_lower), float(x_upper)))
+
+    cleaned: List[float] = []
+    for raw in values:
+        as_float = _coerce_float(raw)
+        if as_float is None:
+            continue
+        if lo is not None and (as_float < lo - _BOUND_EPSILON or as_float > hi + _BOUND_EPSILON):
+            continue
+        cleaned.append(as_float)
+
+    if not cleaned:
+        return None
+
+    cleaned.sort()
+    deduped: List[float] = [cleaned[0]]
+    for value in cleaned[1:]:
+        if abs(value - deduped[-1]) > _DEDUP_EPSILON:
+            deduped.append(value)
+
+    return deduped or None
+
+
+def format_split_lines(values) -> Optional[str]:
+    """Render ``splitLines`` as the JCAMP token ``"v1;v2;v3"`` or ``None``."""
+    if not values:
+        return None
+    return ';'.join(_format_number(v) for v in values)
+
+
+def parse_split_lines(text) -> Optional[List[float]]:
+    """Inverse of :func:`format_split_lines`. Tolerates surrounding quotes."""
+    if text is None:
+        return None
+    if not isinstance(text, str):
+        return None
+    cleaned = text.strip().strip('"').strip("'").strip()
+    if not cleaned:
+        return None
+    parts = [chunk.strip() for chunk in cleaned.split(';') if chunk.strip()]
+    out: List[float] = []
+    for part in parts:
+        as_float = _coerce_float(part)
+        if as_float is not None:
+            out.append(as_float)
+    return out or None
+
+
+def sanitize_group_id(value) -> Optional[str]:
+    """Return a cleaned ``visualSplitGroupId`` or ``None``."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, str):
+        cleaned = value.strip()
+    else:
+        try:
+            cleaned = str(value).strip()
+        except Exception:
+            return None
+    if not cleaned:
+        return None
+    if not _GROUP_ID_RE.match(cleaned):
+        return None
+    return cleaned
+
+
+def format_observed_integrals_groups_table(items: Iterable[dict]) -> List[str]:
+    out: List[str] = []
+    for idx, item in enumerate(items):
+        if not isinstance(item, dict):
+            continue
+        group_id = sanitize_group_id(item.get('visualSplitGroupId'))
+        if group_id is None:
+            continue
+        out.append('{}, {}\n'.format(idx, group_id))
+    return out
+
+
+def parse_observed_integrals_groups_table(text: str) -> Dict[int, str]:
+    if not text:
+        return {}
+    mapping: Dict[int, str] = {}
+    for raw_line in text.splitlines():
+        line = raw_line.strip().lstrip('(').rstrip(')')
+        if not line:
+            continue
+        parts = [c.strip() for c in line.split(',')]
+        if len(parts) < 2:
+            continue
+        try:
+            idx = int(parts[0])
+        except (TypeError, ValueError):
+            continue
+        group_id_raw = ','.join(parts[1:]).strip().strip('"').strip("'")
+        group_id = sanitize_group_id(group_id_raw)
+        if group_id is None:
+            continue
+        mapping[idx] = group_id
+    return mapping
+
+
+def parse_observed_integrals_table(
+    text: str,
+    groups_text: Optional[str] = None,
+) -> List[dict]:
+    if not text:
+        return []
+
+    rows: List[dict] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        line = line.lstrip('(').rstrip(')')
+        cols = [c.strip() for c in line.split(',')]
+        if len(cols) < 3:
+            continue
+        xL = _coerce_float(cols[0])
+        xU = _coerce_float(cols[1])
+        area = _coerce_float(cols[2])
+        if xL is None or xU is None or area is None:
+            continue
+        item: dict = {'xL': xL, 'xU': xU, 'area': area}
+        if len(cols) >= 4:
+            abs_area = _coerce_float(cols[3])
+            if abs_area is not None:
+                item['absoluteArea'] = abs_area
+        if len(cols) >= 5:
+            split_lines = parse_split_lines(cols[4])
+            if split_lines:
+                item['splitLines'] = split_lines
+        rows.append(item)
+
+    if groups_text:
+        groups = parse_observed_integrals_groups_table(groups_text)
+        for idx, group_id in groups.items():
+            if 0 <= idx < len(rows):
+                rows[idx]['visualSplitGroupId'] = group_id
+    return rows

--- a/chem_spectra/lib/composer/ni.py
+++ b/chem_spectra/lib/composer/ni.py
@@ -14,6 +14,9 @@ import csv
 from chem_spectra.lib.composer.base import (  # noqa: E402, F401
     extrac_dic, calc_npoints, BaseComposer
 )
+from chem_spectra.lib.composer.integration_extras import (  # noqa: E402
+    parse_split_lines,
+)
 from chem_spectra.lib.shared.calc import (  # noqa: E402
     calc_mpy_center, calc_ks, get_curve_endpoint, cal_slope, cal_xyIntegration,
 )
@@ -181,6 +184,11 @@ class NIComposer(BaseComposer):
             '##$OBSERVEDINTEGRALS= (X Y Z)\n',
         ]
 
+    def __gen_headers_integration_groups(self):
+        return [
+            '##$OBSERVEDINTEGRALSGROUPS=\n',
+        ]
+
     def __gen_headers_mpy_integ(self):
         return [
             '##$OBSERVEDMULTIPLETS=\n',
@@ -340,6 +348,10 @@ class NIComposer(BaseComposer):
         meta.extend(self.__gen_headers_im())
         meta.extend(self.__gen_headers_integration())
         meta.extend(self.gen_integration_info())
+        groups_body = self.gen_integration_groups_info()
+        if groups_body:
+            meta.extend(self.__gen_headers_integration_groups())
+            meta.extend(groups_body)
         meta.extend(self.__gen_headers_mpy_integ())
         meta.extend(self.gen_mpy_integ_info())
         meta.extend(self.__gen_headers_mpy_peaks())
@@ -543,7 +555,12 @@ class NIComposer(BaseComposer):
                     xLStr = split_itg[0].strip()
                     xUStr = split_itg[1].strip()
                     areaStr = split_itg[2].strip()
-                    self.all_itgs.append({'xL': float(xLStr), 'xU': float(xUStr), 'area': float(areaStr)})    # noqa: E501
+                    rebuilt_itg = {'xL': float(xLStr), 'xU': float(xUStr), 'area': float(areaStr)}
+                    if len(split_itg) >= 5:
+                        rebuilt_split_lines = parse_split_lines(split_itg[4])
+                        if rebuilt_split_lines:
+                            rebuilt_itg['splitLines'] = rebuilt_split_lines
+                    self.all_itgs.append(rebuilt_itg)
         
 
         # ----- Calculate multiplicity -----

--- a/chem_spectra/lib/converter/jcamp/ni.py
+++ b/chem_spectra/lib/converter/jcamp/ni.py
@@ -68,6 +68,7 @@ class JcampNIConverter:  # nmr & IR
         self.auto_peaks = None
         self.edit_peaks = None
         self.itg_table = []
+        self.itg_groups_table = []
         self.mpy_itg_table = []
         self.mpy_pks_table = []
         self.max_min_peaks_table = []
@@ -576,6 +577,9 @@ class JcampNIConverter:  # nmr & IR
         target = self.dic.get('$OBSERVEDINTEGRALS')
         if target:
             self.itg_table = ['\n'.join(target[0].split('\n')[1:]), '\n']
+        target_groups = self.dic.get('$OBSERVEDINTEGRALSGROUPS')
+        if target_groups:
+            self.itg_groups_table = [target_groups[0], '\n']
 
     def __read_multiplicity_from_file(self):
         target1 = self.dic.get('$OBSERVEDMULTIPLETS')


### PR DESCRIPTION
# Persist visual split integration groups in JCAMP

## Summary

Adds support for the new `visualSplitGroupId` field that
`react-spectra-editor` attaches to integration stack items when an
integration is visually split into sub-parts. The link between
sub-parts is now persisted in the JCAMP file via a new optional
record, so visual splits survive a save / reload cycle.

## What changed

- **Writer** (`composer/base.py`, `composer/ni.py`)
  - Normalize and propagate `visualSplitGroupId` through
    `prepare_itg_mpy`, including when the integration is fused into
    a multiplet.
  - New `BaseComposer.gen_integration_groups_info()` that produces
    the body of `##$OBSERVEDINTEGRALSGROUPS=` from the stack.
  - `NIComposer.__compose` emits the new record right after
    `##$OBSERVEDINTEGRALS=`, **only when at least one item carries a
    valid `visualSplitGroupId`**.

- **Reader** (`converter/jcamp/ni.py`)
  - Capture `$OBSERVEDINTEGRALSGROUPS` as raw text in a new
    `itg_groups_table` attribute, mirroring how `itg_table` is
    handled. Pure passthrough cycles re-emit the original block.

- **Helpers** (`composer/integration_extras.py`)
  - `sanitize_group_id` — validates against the same regex used by
    the frontend (`[A-Za-z0-9._-]+`).
  - `format_observed_integrals_groups_table` — renders the record
    body from a list of stack items.
  - `parse_observed_integrals_groups_table` — parses the record
    back into `{idx: groupId}`.
  - `parse_observed_integrals_table` now accepts an optional
    `groups_text` argument and merges the mapping into the returned
    rows as `visualSplitGroupId`.

## JCAMP format

```
##$OBSERVEDINTEGRALS= (X Y Z)
8.50, 8.10, 1.00, 0.42
7.30, 7.10, 2.04, 0.95
7.10, 6.80, 3.06, 1.42
3.40, 3.20, 1.00, 0.41
##$OBSERVEDINTEGRALSGROUPS=
1, vsg-lxyz-1
2, vsg-lxyz-1
```

- `idx` is the 0-based position in the `$OBSERVEDINTEGRALS` table.
- The record is omitted entirely when no item carries a group id.

## Backward compatibility

- `$OBSERVEDINTEGRALS` format is unchanged.
- The new record is only emitted when needed, so legacy JCAMP output
  stays byte-identical.
- Stacks without `visualSplitGroupId` produce no extra record.
- Malformed or missing `$OBSERVEDINTEGRALSGROUPS` blocks are treated
  as absent (no error).
