### PR TITLE
chore: prepare v1.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chem-spectra-app"
-version = "1.4.0"
+version = "1.5.0"
 requires-python = ">= 3.12"
 description = "A backend service to process files obtained from chemical spectroscopy."
 license = "MIT"


### PR DESCRIPTION
Bump version from 1.4.0 to 1.5.0 to prepare the `v1.5.0` release tag.

Release notes: https://github.com/ComPlat/chem-spectra-app/releases/tag/v1.5.0