### PR TITLE
chore: prepare v1.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chem-spectra-app"
-version = "1.5.0"
+version = "1.5.1"
 requires-python = ">= 3.12"
 description = "A backend service to process files obtained from chemical spectroscopy."
 license = "MIT"


### PR DESCRIPTION
Bump tag from v1.5.0 to v1.5.1.

## Included since v1.5.0
- fix(transformer): restore standalone HPLC UVVIS routing to NI path in jcamp2cvp (#281)
- docs: replace legacy backend docs with clearer guides (#266)

## Release
Version bumped in `pyproject.toml`: `1.5.0` → `1.5.1`. After merge, tag `v1.5.1` on the merge commit and publish the GitHub release.