### PR TITLE
fix(composer): normalize XYPOINTS LDR and keep it out of NTUPLES original metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ build/
 !/chem_spectra/tmp/.keep
 
 /src/
+
+CLAUDE.md

--- a/chem_spectra/lib/composer/base.py
+++ b/chem_spectra/lib/composer/base.py
@@ -49,7 +49,7 @@ def is_metadata_to_be_ignored(keyword, is_ntuples=False):
         # a stray leftover LDR that duplicates the NTUPLES data table, so
         # it should be suppressed like XYDATA/XYDATA_OLD already are.
         return is_ntuples
-    return keyword in ['__comments', '_comments', 'FIRST', 'LAST', 'XYDATA_OLD', 'NTUPLES', 'PEAKASSIGNMENTS', 'XYDATA', '$CSSIMULATIONPEAKS', 'XFACTOR', 'YFACTOR', 'FIRSTX', 'FIRSTY', 'DATACLASS', 'PEAKTABLE', 'DATATYPE', 'DATACLASS']
+    return keyword in ['__comments', '_comments', 'FIRST', 'LAST', 'XYDATA_OLD', 'NTUPLES', 'PEAKASSIGNMENTS', 'XYDATA', '$CSSIMULATIONPEAKS', 'XFACTOR', 'YFACTOR', 'FIRSTX', 'FIRSTY', 'DATACLASS', 'PEAKTABLE', 'DATATYPE']
 
 
 TEXT_DATA_TABLE = '##XYDATA= (X++(Y..Y))\n'

--- a/chem_spectra/lib/composer/base.py
+++ b/chem_spectra/lib/composer/base.py
@@ -31,7 +31,7 @@ def coupling_string(js):
     return ', ' + ' '.join([str(j) for j in js])
 
 
-def is_metadata_to_be_ignored(keyword):
+def is_metadata_to_be_ignored(keyword, is_ntuples=False):
     chemspectra_managed = {
         '$OBSERVEDINTEGRALS',
         '$OBSERVEDINTEGRALSGROUPS',
@@ -42,6 +42,13 @@ def is_metadata_to_be_ignored(keyword):
     }
     if keyword in chemspectra_managed:
         return True
+    if keyword == 'XYPOINTS':
+        # XYPOINTS is the authoritative data table for XYPOINTS-classified
+        # spectra (e.g. HPLC) and must stay in the original-metadata dump.
+        # For NTUPLES-classified spectra (e.g. MASS SPECTRUM / LC-MS) it's
+        # a stray leftover LDR that duplicates the NTUPLES data table, so
+        # it should be suppressed like XYDATA/XYDATA_OLD already are.
+        return is_ntuples
     return keyword in ['__comments', '_comments', 'FIRST', 'LAST', 'XYDATA_OLD', 'NTUPLES', 'PEAKASSIGNMENTS', 'XYDATA', '$CSSIMULATIONPEAKS', 'XFACTOR', 'YFACTOR', 'FIRSTX', 'FIRSTY', 'DATACLASS', 'PEAKTABLE', 'DATATYPE', 'DATACLASS']
 
 
@@ -137,8 +144,9 @@ class BaseComposer:
         content = self.__header_original_metadata()
         if self.core.dic is None: return content
 
+        is_ntuples = 'NTUPLES' in (self.core.dic.get('DATACLASS') or [])
         for key, value in self.core.dic.items():
-            if is_metadata_to_be_ignored(key):
+            if is_metadata_to_be_ignored(key, is_ntuples):
                 continue
             str_value = value
             str_key = key

--- a/chem_spectra/lib/composer/lcms_converter_app.py
+++ b/chem_spectra/lib/composer/lcms_converter_app.py
@@ -1,3 +1,4 @@
+import re
 import tempfile
 import json
 import logging
@@ -24,6 +25,39 @@ _UVVIS_DATA_TYPE_TOKENS = (
 )
 
 _MARKER_SCAN_CHUNK = 65536
+
+# jcampconverter (the frontend's JCAMP parser, react-spectra-editor's
+# ExtractJcamp) doesn't support the ##XYPOINTS= LDR, only
+# ##XYDATA=/##DATA TABLE=/##PEAK TABLE=. NIComposer/MSComposer always
+# regenerate their primary data block as ##XYDATA=, so the frontend never
+# sees ##XYPOINTS= from those paths. This LC/MS path instead passes source
+# bytes through verbatim, so a source file that uses ##XYPOINTS= (as
+# chemotion-converter-app does for some LC/MS traces, e.g. TIC) breaks
+# client-side rendering. Normalize it here to match the other paths.
+_XYPOINTS_LDR_RE = re.compile(r'(?im)^(##\s*)XYPOINTS(\s*=)')
+_DATACLASS_XYPOINTS_RE = re.compile(r'(?im)^(##\s*DATA\s*CLASS\s*=\s*)XYPOINTS\b')
+
+
+def _normalize_xypoints_ldr(path: Optional[str]) -> None:
+    if not path:
+        return
+    try:
+        with open(path, 'r', encoding='utf-8', errors='ignore') as handle:
+            content = handle.read()
+    except OSError:
+        return
+
+    if not _XYPOINTS_LDR_RE.search(content):
+        return
+
+    updated = _XYPOINTS_LDR_RE.sub(r'\1XYDATA\2', content)
+    updated = _DATACLASS_XYPOINTS_RE.sub(r'\1XYDATA', updated)
+
+    try:
+        with open(path, 'w', encoding='utf-8') as handle:
+            handle.write(updated)
+    except OSError:
+        pass
 
 
 def has_uvvis_peak_marker(path: Optional[str]) -> bool:
@@ -52,6 +86,8 @@ class LCMSConverterAppComposer:
         self._image = image
         self.params = params
         self._peaks_applied = False
+        for jdx_file in self.data:
+            _normalize_xypoints_ldr(getattr(jdx_file, 'name', None))
         self._ensure_uvvis_peak_file()
 
     @staticmethod

--- a/tests/lib/composer/test_base_composer.py
+++ b/tests/lib/composer/test_base_composer.py
@@ -38,3 +38,46 @@ def test_base_composer_generate_original_metadata(jcamp_file_1h):
       '###.AVERAGES= 16\n',
       '\n\n'
     ]
+
+def test_base_composer_generate_original_metadata_keeps_xypoints_when_not_ntuples(jcamp_file_1h):
+    # XYPOINTS is the authoritative data table for XYPOINTS-classified
+    # spectra (e.g. HPLC) and must still appear in the original-metadata
+    # dump when the source isn't NTUPLES.
+    base_converter = JcampBaseConverter(jcamp_file_1h)
+    metadata = {
+        "DATACLASS": ["XYPOINTS"],
+        ".AVERAGES": "16",
+        "XYPOINTS": ["(XY..XY)\n999, 999;\n888, 888;"],
+    }
+    base_converter.dic = metadata
+    composer = BaseComposer(core=base_converter)
+    auto_metadata = composer.generate_original_metadata()
+    assert auto_metadata == [
+      '\n',
+      '$$ === CHEMSPECTRA ORIGINAL METADATA ===\n',
+      '###.AVERAGES= 16\n',
+      '###XYPOINTS= (XY..XY)\n999, 999;\n888, 888;\n',
+      '\n\n'
+    ]
+
+def test_base_composer_generate_original_metadata_ignores_xypoints_for_ntuples(jcamp_file_1h):
+    # A stray top-level XYPOINTS LDR alongside NTUPLES-classified data (e.g.
+    # MASS SPECTRUM / LC-MS) duplicates the real NTUPLES data table and must
+    # not leak into the CHEMSPECTRA ORIGINAL METADATA dump, same as
+    # XYDATA/XYDATA_OLD already don't.
+    base_converter = JcampBaseConverter(jcamp_file_1h)
+    metadata = {
+        "DATACLASS": ["NTUPLES"],
+        ".AVERAGES": "16",
+        "XYPOINTS": ["(XY..XY)\n999, 999;\n888, 888;"],
+        "XYDATA_OLD": ["(XY..XY)\n999, 999;\n888, 888;"],
+    }
+    base_converter.dic = metadata
+    composer = BaseComposer(core=base_converter)
+    auto_metadata = composer.generate_original_metadata()
+    assert auto_metadata == [
+      '\n',
+      '$$ === CHEMSPECTRA ORIGINAL METADATA ===\n',
+      '###.AVERAGES= 16\n',
+      '\n\n'
+    ]

--- a/tests/lib/composer/test_lcms_converter_app.py
+++ b/tests/lib/composer/test_lcms_converter_app.py
@@ -52,6 +52,27 @@ MASS_TIC_JDX = """##TITLE=Spectrum
 ##END=
 """
 
+# jcampconverter (react-spectra-editor's frontend JCAMP parser) can't parse
+# the ##XYPOINTS= LDR — only ##XYDATA=/##DATA TABLE=/##PEAK TABLE=. Some
+# chemotion-converter-app TIC exports use ##XYPOINTS= as the primary data
+# block, which this composer must normalize since it otherwise passes
+# source bytes through untouched.
+XYPOINTS_TIC_JDX = """##TITLE=Spectrum
+##JCAMP-DX=5.00 $$ chemotion-converter-app (1.9.2)
+##DATA TYPE=MASS TIC
+##DATA CLASS=XYPOINTS
+##XUNITS=MINUTES
+##YUNITS=ARBITRARY UNITS
+##FIRSTX=0.0
+##LASTX=2.0
+##NPOINTS=3
+##XYPOINTS= (XY..XY)
+0.0, 100;
+1.0, 5000;
+2.0, 200;
+##END=
+"""
+
 
 def _named_tmp(content: str) -> tempfile.NamedTemporaryFile:
     tf = tempfile.NamedTemporaryFile(suffix=".jdx", delete=False)
@@ -79,6 +100,18 @@ def uvvis_tmp():
 @pytest.fixture
 def mass_tic_tmp():
     tf = _named_tmp(MASS_TIC_JDX)
+    yield tf
+    try:
+        tf.close()
+        if os.path.exists(tf.name):
+            os.unlink(tf.name)
+    except OSError:
+        pass
+
+
+@pytest.fixture
+def xypoints_tic_tmp():
+    tf = _named_tmp(XYPOINTS_TIC_JDX)
     yield tf
     try:
         tf.close()
@@ -173,3 +206,61 @@ def test_preview_pipeline_can_now_extract_uvvis(uvvis_tmp):
     assert result is not None
     xs, ys, _edit_peaks, _integrations, _wl = result
     assert len(xs) > 0 and len(ys) > 0
+
+
+def test_init_normalizes_xypoints_ldr_to_xydata(xypoints_tic_tmp):
+    # jcampconverter (the frontend parser) can't read ##XYPOINTS=. This
+    # composer passes source bytes through untouched otherwise, so it must
+    # rewrite the LDR (and the DATA CLASS declaring it) to ##XYDATA=,
+    # matching what NIComposer/MSComposer already normalize to.
+    LCMSConverterAppComposer([xypoints_tic_tmp], None, None)
+
+    with open(xypoints_tic_tmp.name, "r", encoding="utf-8", errors="ignore") as h:
+        content = h.read()
+
+    assert "##XYPOINTS=" not in content
+    assert "##DATA CLASS=XYDATA" in content
+    assert "##XYDATA= (XY..XY)" in content
+    # data values themselves must be untouched
+    assert "0.0, 100;" in content
+    assert "1.0, 5000;" in content
+    assert "2.0, 200;" in content
+
+
+def test_init_leaves_non_xypoints_ldr_untouched(mass_tic_tmp):
+    with open(mass_tic_tmp.name, "r", encoding="utf-8", errors="ignore") as h:
+        before = h.read()
+
+    LCMSConverterAppComposer([mass_tic_tmp], None, None)
+
+    with open(mass_tic_tmp.name, "r", encoding="utf-8", errors="ignore") as h:
+        after = h.read()
+
+    assert before == after
+
+
+def test_init_does_not_touch_triple_hash_xypoints_metadata_echo():
+    # ###XYPOINTS= (three hashes) is chem-spectra-app's own original-metadata
+    # echo format, not a live LDR jcampconverter would try to parse — the
+    # normalization must only match the real double-hash ##XYPOINTS= LDR.
+    content = (
+        "##TITLE=Spectrum\n"
+        "##DATA TYPE=CYCLIC VOLTAMMETRY\n"
+        "##DATA CLASS=XYDATA\n"
+        "##XYDATA= (X++(Y..Y))\n"
+        "1 2 3\n"
+        "$$ === CHEMSPECTRA ORIGINAL METADATA ===\n"
+        "###XYPOINTS= (XY..XY)\n"
+        "0.0, 100;\n"
+        "##END=\n"
+    )
+    tf = _named_tmp(content)
+    try:
+        LCMSConverterAppComposer([tf], None, None)
+        with open(tf.name, "r", encoding="utf-8", errors="ignore") as h:
+            after = h.read()
+        assert after == content
+    finally:
+        tf.close()
+        if os.path.exists(tf.name):
+            os.unlink(tf.name)


### PR DESCRIPTION
## Summary

  Two related fixes around how `##XYPOINTS=` is handled when composing/passing through JCAMP output, both stemming from
  the same investigation into a mismatched `DATA CLASS`/LDR pairing produced by `chemotion-converter-app`:

  - **Stop `##XYPOINTS=` leaking into original metadata for NTUPLES sources.**
  `BaseComposer.generate_original_metadata()` already suppressed `XYDATA`/`XYDATA_OLD` from the `CHEMSPECTRA ORIGINAL
  METADATA` dump, but not `XYPOINTS` — so a stray top-level `##XYPOINTS=` LDR alongside NTUPLES-classified data (e.g.
  MASS SPECTRUM / LC-MS) duplicated the real NTUPLES data table in the output. Fixed by scoping the suppression to
  NTUPLES sources only — `XYPOINTS` is the authoritative data table for XYPOINTS-classified spectra (e.g. HPLC) and must
  stay in that dump for those, so a blanket ignore would have broken existing HPLC output.

  - **Normalize `##XYPOINTS=` to `##XYDATA=` for LC/MS pass-through files.** `react-spectra-editor`'s `jcampconverter`
  (the frontend's JCAMP parser) can read `##XYDATA=`, `##DATA TABLE=`, and `##PEAK TABLE=`, but not `##XYPOINTS=`.
  `NIComposer`/`MSComposer` always regenerate their primary data block as `##XYDATA=` regardless of the source format,
  so the frontend never sees `##XYPOINTS=` from those paths — but `LCMSConverterAppComposer` (the LC/MS pass-through
  path) returns source bytes verbatim for unedited uploads, so a TIC file that used `##XYPOINTS=` (as
  `chemotion-converter-app` does for some exports) broke client-side rendering. Normalized on init, rewriting `##DATA
  CLASS=XYPOINTS` alongside the LDR to avoid re-introducing a DATACLASS/LDR mismatch. The `###XYPOINTS=` (three-hash)
  original-metadata echo from the first fix is untouched — it isn't a live LDR `jcampconverter` scans for.

  Also: gitignore `CLAUDE.md`, and a minor duplicate-entry cleanup in the metadata ignore list.

  ## Test plan

  - [x] `python -m pytest tests/` — 224 passed (1 pre-existing test deselected, requires `msconvert_docker`)
  - [x] New regression tests: `test_base_composer_generate_original_metadata_keeps_xypoints_when_not_ntuples`,
  `test_base_composer_generate_original_metadata_ignores_xypoints_for_ntuples`,
  `test_init_normalizes_xypoints_ldr_to_xydata`, `test_init_leaves_non_xypoints_ldr_untouched`,
  `test_init_does_not_touch_triple_hash_xypoints_metadata_echo`
  - [x] Confirmed both fixes are meaningful by reverting each in isolation and observing the corresponding test fail
  - [x] Confirmed the original HPLC golden-file tests (`test_spectra_im_hplc.py`) still pass — an earlier, broader
  version of the first fix regressed these before scoping it to NTUPLES only

  🤖 Generated with [Claude Code](https://claude.com/claude-code)