### PR TITLE
fix(converter): read XY pairs when DATA CLASS and the table LDR disagree

### DIFF
--- a/chem_spectra/lib/converter/jcamp/base.py
+++ b/chem_spectra/lib/converter/jcamp/base.py
@@ -95,19 +95,37 @@ class JcampBaseConverter:
                 return key
         return ''
 
+    # Data tables nmrglue may expose, in the order we trust them. Note that
+    # nmrglue renames a plain ##XYDATA= record to XYDATA_OLD on read, so
+    # 'XYDATA' is never a live key here.
+    DATA_TABLE_KEYS = ('XYPOINTS', 'XYDATA_OLD')
+
     def __set_dataclass(self):
         data_class = self.dataclasses
         if 'XYPOINTS' in data_class:
             return 'XYPOINTS'
         elif 'XYDATA' in data_class:
             return 'XYDATA_OLD'
+        # Some valid JCAMP-DX files omit ##DATA CLASS altogether. Fall back to
+        # whichever data table the reader actually found.
+        for key in self.DATA_TABLE_KEYS:
+            if self.dic.get(key):
+                return key
         return ''
 
     def __set_dataformat(self):
-        try:
-            return self.dic[self.dataclass][0].split('\n')[0]
-        except: # noqa
-            pass
+        # The declared ##DATA CLASS and the actual data-table LDR can disagree.
+        # chemotion-converter-app 1.9.0-1.9.2 wrote ##DATA CLASS=XYPOINTS
+        # alongside a ##XYDATA=(XY..XY) table; reading the format off the
+        # declared class alone raised KeyError and silently fell back to
+        # '(X++(Y..Y))', which makes the callers synthesise an evenly spaced X
+        # axis and throw the real X column away. Probe the declared class
+        # first, then the other tables the reader may have populated.
+        keys = (self.dataclass,) + self.DATA_TABLE_KEYS
+        for key in keys:
+            values = self.dic.get(key) if key else None
+            if values:
+                return values[0].split('\n')[0]
         return '(X++(Y..Y))'
 
     def __is_em_wave(self):

--- a/chem_spectra/lib/converter/jcamp/data_parse.py
+++ b/chem_spectra/lib/converter/jcamp/data_parse.py
@@ -13,10 +13,14 @@ def __num_pts(base, x_max, x_min):
 
 def __parse_xy_points(base):
     pts = []
-    if 'XYPOINTS' in base.dic:
+    if base.dic.get('XYPOINTS'):
         pts = base.dic['XYPOINTS'][0].split('\n')[1:]
     elif base.data_format and base.data_format == '(XY..XY)':
-        pts = base.dic['XYDATA_OLD'][0].split('\n')[1:]
+        # A ##XYDATA= record carrying an (XY..XY) table, e.g. anything written
+        # by chemotion-converter-app 1.9.0-1.9.2. nmrglue exposes it as
+        # XYDATA_OLD.
+        xydata_old = base.dic.get('XYDATA_OLD')
+        pts = xydata_old[0].split('\n')[1:] if xydata_old else []
     return np.array([[float(p) for p in pt.split(',')]for pt in pts])
 
 

--- a/tests/lib/converter/jcamp/test_xypoints_dataclass.py
+++ b/tests/lib/converter/jcamp/test_xypoints_dataclass.py
@@ -1,0 +1,107 @@
+import numpy as np
+import pytest
+
+from chem_spectra.lib.converter.jcamp.base import JcampBaseConverter
+from chem_spectra.lib.converter.jcamp.ni import JcampNIConverter
+
+# Deliberately non-uniform, non-monotonic X — a miniature cyclic sweep. An
+# evenly-spaced reconstruction from FIRSTX/LASTX cannot reproduce it, which is
+# what makes it a usable probe.
+XS = [0.0, 0.1, 0.3, 0.6, 0.4, 0.2, 0.05]
+YS = [1.0, 1.4, 2.1, 3.0, 2.4, 1.6, 1.1]
+
+
+def _jcamp(data_class, table_label):
+    rows = ''.join(
+        '{:.6E}, {:.6E}\n'.format(x, y) for x, y in zip(XS, YS)
+    )
+    header = '' if data_class is None else '##DATA CLASS={}\n'.format(data_class)
+    return (
+        '##TITLE=Spectrum\n'
+        '##JCAMP-DX=5.00\n'
+        '##DATA TYPE=CYCLIC VOLTAMMETRY\n'
+        + header +
+        '##XUNITS=Voltage in V\n'
+        '##YUNITS=Current in A\n'
+        '##FIRSTX={:.6E}\n'.format(XS[0]) +
+        '##LASTX={:.6E}\n'.format(XS[-1]) +
+        '##MINX={:.6E}\n'.format(min(XS)) +
+        '##MAXX={:.6E}\n'.format(max(XS)) +
+        '##MINY={:.6E}\n'.format(min(YS)) +
+        '##MAXY={:.6E}\n'.format(max(YS)) +
+        '##NPOINTS={}\n'.format(len(XS)) +
+        '##FIRSTY={:.6E}\n'.format(YS[0]) +
+        '##{}=(XY..XY)\n'.format(table_label) +
+        rows +
+        '##END=\n'
+    )
+
+
+def _write(tmp_path, name, content):
+    path = tmp_path / name
+    path.write_text(content)
+    return str(path)
+
+
+def _read_xs(path):
+    return np.asarray(JcampNIConverter(JcampBaseConverter(path)).xs)
+
+
+def test_conformant_xypoints_keeps_real_x(tmp_path):
+    """##DATA CLASS=XYPOINTS + ##XYPOINTS= — converter <=1.8.0 and >=1.9.3."""
+    path = _write(tmp_path, 'new.jdx', _jcamp('XYPOINTS', 'XYPOINTS'))
+    base = JcampBaseConverter(path)
+
+    assert base.data_format == '(XY..XY)'
+    np.testing.assert_allclose(_read_xs(path), XS, rtol=1e-6)
+
+
+def test_mismatched_xydata_label_keeps_real_x(tmp_path):
+    """##DATA CLASS=XYPOINTS + ##XYDATA=(XY..XY) — converter 1.9.0-1.9.2.
+
+    Regression guard: before the fix, __set_dataformat could not find a
+    'XYPOINTS' key, fell back to '(X++(Y..Y))', and the X axis was
+    re-synthesised as linspace(FIRSTX, LASTX) — collapsing a closed cyclic
+    sweep to a near-flat line.
+    """
+    path = _write(tmp_path, 'old.jdx', _jcamp('XYPOINTS', 'XYDATA'))
+    base = JcampBaseConverter(path)
+
+    assert base.data_format == '(XY..XY)'
+    np.testing.assert_allclose(_read_xs(path), XS, rtol=1e-6)
+
+
+def test_missing_dataclass_still_finds_xypoints(tmp_path):
+    """##XYPOINTS= with no ##DATA CLASS at all."""
+    path = _write(tmp_path, 'no_dataclass.jdx', _jcamp(None, 'XYPOINTS'))
+    base = JcampBaseConverter(path)
+
+    assert base.dataclass == 'XYPOINTS'
+    assert base.data_format == '(XY..XY)'
+    np.testing.assert_allclose(_read_xs(path), XS, rtol=1e-6)
+
+
+def test_equally_spaced_xydata_is_untouched(tmp_path):
+    """A genuine ##DATA CLASS=XYDATA + (X++(Y..Y)) file must not be rerouted."""
+    content = (
+        '##TITLE=Spectrum\n'
+        '##JCAMP-DX=5.00\n'
+        '##DATA TYPE=CYCLIC VOLTAMMETRY\n'
+        '##DATA CLASS=XYDATA\n'
+        '##XUNITS=Voltage in V\n'
+        '##YUNITS=Current in A\n'
+        '##XFACTOR=1.0\n'
+        '##YFACTOR=1.0\n'
+        '##FIRSTX=0.0\n'
+        '##LASTX=6.0\n'
+        '##DELTAX=1.0\n'
+        '##NPOINTS=7\n'
+        '##XYDATA=(X++(Y..Y))\n'
+        '0 1 2 3 4 5 6\n'
+        '##END=\n'
+    )
+    path = _write(tmp_path, 'xydata.jdx', content)
+    base = JcampBaseConverter(path)
+
+    assert base.dataclass == 'XYDATA_OLD'
+    assert base.data_format == '(X++(Y..Y))'


### PR DESCRIPTION
## Problem

A JCAMP file can declare `##DATA CLASS=XYPOINTS` while carrying the data as
`##XYDATA=(XY..XY)`. `chemotion-converter-app` wrote exactly that shape between
[`88e48d4c`](https://github.com/ComPlat/chemotion-converter-app/commit/88e48d4c) (2026-03-26) and
[`b39482cc`](https://github.com/ComPlat/chemotion-converter-app/commit/b39482cc0c0058ce876301d88b81a85c92280bba) (2026-07-20, PR #244) —
released as `complat/dev:converter-1.9.0` … `converter-1.9.3-alpha3`.

`__set_dataformat` resolved the format by indexing `self.dic` with the **declared** data class
only. nmrglue renames a plain `##XYDATA=` record to `XYDATA_OLD` on read, so for these files
`dic['XYPOINTS']` does not exist, the bare `except` swallowed the `KeyError`, and the format
defaulted to `'(X++(Y..Y))'`. That matched neither branch of `__parse_xy_points`, so
`JcampNIConverter.__read_xs` skipped `make_ni_data_xs` and rebuilt X as
`linspace(FIRSTX, LASTX)` — **silently discarding the measured X column**. Y was unaffected.

The damage scales with how non-uniform X is. A closed cyclic voltammetry sweep ends where it
starts, so `FIRSTX ≈ LASTX` and the reconstruction collapses the entire sweep:

| Input | `data_format` | X (first 4) | X span |
|---|---|---|---|
| `##XYPOINTS=(XY..XY)` | `(XY..XY)` | −0.150194, −0.145189, −0.140188, −0.135201 | −0.150197 … **0.700003** |
| `##XYDATA=(XY..XY)` | `(X++(Y..Y))` | −0.150194, −0.150194, −0.150194, −0.150194 | −0.150197 … **−0.150194** |

0.85 V of sweep reduced to a 3 µV flat line, measured on a Gamry `.DTA` reference file.

All 30 bundled converter profiles declare `DATA CLASS: XYPOINTS`, so this is not CV-specific —
UV-Vis, IR, SEC/GPC, TGA, DSC, sorption and XRD route through the same path. It is also not
version-specific on this side: chem-spectra **1.4.0 and 1.5.2-alpha behave identically**.

## Change

- `__set_dataformat` probes the declared class, then the tables the reader actually populated
  (`XYPOINTS`, `XYDATA_OLD`), before defaulting.
- `__set_dataclass` falls back the same way when `##DATA CLASS` is absent entirely. This also
  covers the case fixed on the stale `fix/xy-points-dataclass-fallback` branch (`8d5edde`,
  open since 2026-02-06) — note that version tested `dic['XYDATA']`, a key nmrglue never
  leaves in place, so its second branch was dead code.
- `__parse_xy_points` no longer raises when `XYDATA_OLD` is missing.

Read path only — no composer output changes.

## Impact on existing data

Affected derivatives are **repairable**: the stored converter `.zip` still holds the true XY
pairs, so `POST /api/v1/attachments/regenerate_spectrum` (the ELN's *Reprocess* button) fixes a
dataset in place once this is deployed. Without it, regenerating reproduces the same distortion.

The affected window is dev-ring only and 9 days wide — `ptrxyz/chemotion:converter-3.1.2` is
built from converter **v1.8.0**, which already emitted the conformant `##XYPOINTS=`, and
`converter-1.9.3-alpha4` onward has the fix. No tagged ELN release ever shipped the bad label.

## Tests

`tests/lib/converter/jcamp/test_xypoints_dataclass.py` — 4 cases over a deliberately
non-uniform, non-monotonic X axis:

| case | before | after |
|---|---|---|
| `##DATA CLASS=XYPOINTS` + `##XYPOINTS=` | pass | pass |
| `##DATA CLASS=XYPOINTS` + `##XYDATA=(XY..XY)` | **fail** | pass |
| `##XYPOINTS=` with no `##DATA CLASS` | **fail** | pass |
| `##DATA CLASS=XYDATA` + `(X++(Y..Y))` (must not reroute) | pass | pass |

Full suite: **223 passed, 6 failed**. The 6 are pre-existing and environmental
(`mimetypes.guess_type` has no `chemical/x-jcamp-dx` registration in the runtime image) — the
identical set fails on unmodified `master`.

Verified end-to-end on the reference file: after the change both label forms produce
**byte-identical spectral data blocks**.

## Follow-ups (not in this PR)

- The converter's NTUPLES path still emits `##XYDATA=(XY..XY)` — the same non-conformance
  `b39482cc` fixed for standalone blocks, and no test covers the intended label.
- No service-version provenance on generated files, which is why affected derivatives can only
  be found by `created_at` against deployment history.