### PR TITLE
fix(converter): honor explicitly cleared peaks_str instead of keeping stale edit peaks

### DIFF
--- a/chem_spectra/lib/converter/jcamp/ni.py
+++ b/chem_spectra/lib/converter/jcamp/ni.py
@@ -422,14 +422,16 @@ class JcampNIConverter:  # nmr & IR
             pass
 
     def __parse_edit(self):
+        peaks_str = self.params['peaks_str']
+        if not peaks_str:
+            self.edit_peaks = {'x': [], 'y': []}
+            return
         edit_x = []
         edit_y = []
-        for p in self.params['peaks_str'].split('#'):
+        for p in peaks_str.split('#'):
             info = p.split(',')
             edit_x.append(float(info[0]))
             edit_y.append(float(info[1]))
-        if len(edit_x) == 0:
-            return
         self.edit_peaks = {'x': edit_x, 'y': edit_y}
 
     def __exec_peak_picking_logic(self, refresh_solvent=False):
@@ -551,7 +553,7 @@ class JcampNIConverter:  # nmr & IR
         self.__read_edit_peaks()
         if not self.auto_peaks or not self.params['delta'] == 0.0:
             self.__run_auto_pick_peak()
-        if self.params['peaks_str']:
+        if self.params['peaks_str'] is not None:
             self.__parse_edit()
 
     def __read_voltammetry_data_from_file(self):

--- a/tests/test_spectra_peaks.py
+++ b/tests/test_spectra_peaks.py
@@ -130,6 +130,34 @@ def test_params_meta_IR_dx():
     meta_target = __target_peaks_meta('ps/ps_' + meta_IR_dx)
     assert ps_meta_content == meta_target
 
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+#
+# explicitly cleared peaks (peaks_str='') must not fall back
+# to auto-detection nor keep any previously saved edit peaks
+# https://github.com/ComPlat/chem-spectra-app/issues/288
+#
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+clear_peaks_params = {
+    'peaks_str': '',
+}
+
+
+def test_clear_peaks_removes_previously_saved_edit_peaks():
+    meta_content = __generated_peaks_meta(
+        'edit/edit_' + H1_dx, clear_peaks_params
+    )
+    edit_block = meta_content.split(separator_a)[0]
+    assert '##NPOINTS=0\n' in edit_block
+    assert '##PEAKTABLE= (XY..XY)\n##END=' in edit_block
+
+
+def test_clear_peaks_does_not_auto_detect():
+    meta_content = __generated_peaks_meta(H1_dx, clear_peaks_params)
+    edit_block = meta_content.split(separator_a)[0]
+    assert '##NPOINTS=0\n' in edit_block
+    assert '##PEAKTABLE= (XY..XY)\n##END=' in edit_block
+
 """
 def test_params_meta_1H():
     ps_meta_content = __generated_peaks_meta(H1_dx, params_1)


### PR DESCRIPTION
## Summary

An empty `peaks_str` (`""`) was falsy, so it was treated the same as an absent `peaks_str`: the previously saved / auto-detected `EDIT_PEAK` table was kept instead of being cleared, making "Clear All Peaks" impossible to persist.

`__parse_edit` is now called whenever `peaks_str is not None` (rather than whenever it is truthy), and an empty string writes an empty edit-peak table instead of falling through to auto-detection.

Fixes #288

## Scope note

This PR previously also carried two further commits, which have been dropped from the branch after review:

- **`##BLOCKS` count** — the implementation counted `$$ === CHEMSPECTRA ... ===` comment lines, which are not JCAMP sub-block delimiters. A 1H file emits 6 such markers but only 3 real `##TITLE=`…`##END=` sub-blocks, so `##BLOCKS=6` was no more correct than the hardcoded `##BLOCKS=1`. Separately, the premise in #290 — that the mismatch is what blanks the chart — does not hold for the parser it names: `jcampconverter@4.1.0` (the parser `@complat/react-spectra-editor` pins) contains no reference to `BLOCKS` anywhere in its source and builds `spectra` from data tables instead, and every chemotion-produced fixture in that project's test suite carries `##BLOCKS=1` and parses correctly. #290 therefore stays open pending a real root cause, and is no longer claimed here.
- **`.OBSERVE FREQUENCY` / `.SOLVENT NAME` in peak-table headers** — writing these into both peak-table headers made each label appear three times per file. The frontend parser keeps one flat `info` map for the whole document and collapses repeated labels into an array, so `solventName` became `["DMSO","DMSO","DMSO"]`, which the info panel renders verbatim and the shift-reference picker fails to match. It would have regressed the display it was meant to fix.

Both are preserved at `refs/backup/pr-289-original` (`bb295c8`) and can be reworked in a follow-up.
